### PR TITLE
Feature - Resend email confirmation

### DIFF
--- a/app/controllers/concerns/api/session_authentication.rb
+++ b/app/controllers/concerns/api/session_authentication.rb
@@ -8,6 +8,8 @@ module Api
 
     included do
       acts_as_token_authentication_handler_for_session
+
+      skip_before_action :verify_authenticity_token
     end
 
     class_methods do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,6 @@
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
 #  confirmation_token     :string
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
@@ -24,6 +18,7 @@
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
@@ -32,9 +27,9 @@ class User < ApplicationRecord
   acts_as_sessionable
 
   # Include default devise modules. Others available are:
-  # :lockable, :timeoutable and :omniauthable
-  devise :confirmable, :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+  # :lockable, :rememberable, :timeoutable, :trackable and :omniauthable
+  devise :confirmable, :database_authenticatable, :registerable, :recoverable,
+         :validatable
 
   # Force devise emails to be sent in workers
   def send_devise_notification(notification, *args)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,12 +9,6 @@
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
 #  confirmation_token     :string
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
@@ -24,6 +18,7 @@
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/app/use_cases/users/create_user.rb
+++ b/app/use_cases/users/create_user.rb
@@ -13,15 +13,18 @@ module Users
     def perform
       init_form
       save_user
+
+      resend_confirmation if unconfirmed_user
     end
 
     private
 
       attr_reader :attributes
       attr_reader :form
+      attr_reader :unconfirmed_user
 
       def init_form
-        @form = UserForm.new(User.new)
+        @form = UserForm.new(find_unconfirmed_user || User.new)
       end
 
       def save_user
@@ -32,6 +35,16 @@ module Users
             add_error_to_base('Failed to save user', form.errors)
           end
         end
+      end
+
+      def find_unconfirmed_user
+        @unconfirmed_user = User.find_by(
+          email: attributes[:email], confirmed_at: nil
+        )
+      end
+
+      def resend_confirmation
+        unconfirmed_user.send_confirmation_instructions
       end
   end
 end

--- a/app/use_cases/users/create_user.rb
+++ b/app/use_cases/users/create_user.rb
@@ -14,7 +14,7 @@ module Users
       init_form
       save_user
 
-      resend_confirmation if unconfirmed_user
+      resend_confirmation if should_resend_confirmation?
     end
 
     private
@@ -41,6 +41,14 @@ module Users
         @unconfirmed_user = User.find_by(
           email: attributes[:email], confirmed_at: nil
         )
+      end
+
+      def should_resend_confirmation?
+        unconfirmed_user.present? && not_sent_recently?
+      end
+
+      def not_sent_recently?
+        (Time.current - unconfirmed_user.confirmation_sent_at) > 1.minute
       end
 
       def resend_confirmation

--- a/db/migrate/20180410110836_devise_create_users.rb
+++ b/db/migrate/20180410110836_devise_create_users.rb
@@ -12,14 +12,14 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.1]
       t.datetime :reset_password_sent_at
 
       ## Rememberable
-      t.datetime :remember_created_at
+      # t.datetime :remember_created_at
 
       ## Trackable
-      t.integer  :sign_in_count, default: 0, null: false
-      t.datetime :current_sign_in_at
-      t.datetime :last_sign_in_at
-      t.inet     :current_sign_in_ip
-      t.inet     :last_sign_in_ip
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.inet     :current_sign_in_ip
+      # t.inet     :last_sign_in_ip
 
       ## Confirmable
       t.string   :confirmation_token
@@ -38,7 +38,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.1]
 
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
-    # add_index :users, :confirmation_token,   unique: true
+    add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,12 +12,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180410111338) do
+ActiveRecord::Schema.define(version: 2018_04_10_111338) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
-  enable_extension 'pgcrypto'
   enable_extension 'citext'
+  enable_extension 'pgcrypto'
+  enable_extension 'plpgsql'
 
   create_table 'devise_sessionable_sessions', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
     t.string 'authentication_token'
@@ -34,18 +34,13 @@ ActiveRecord::Schema.define(version: 20180410111338) do
     t.string 'encrypted_password', default: '', null: false
     t.string 'reset_password_token'
     t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.integer 'sign_in_count', default: 0, null: false
-    t.datetime 'current_sign_in_at'
-    t.datetime 'last_sign_in_at'
-    t.inet 'current_sign_in_ip'
-    t.inet 'last_sign_in_ip'
     t.string 'confirmation_token'
     t.datetime 'confirmed_at'
     t.datetime 'confirmation_sent_at'
     t.string 'unconfirmed_email'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.index ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
     t.index ['email'], name: 'index_users_on_email', unique: true
     t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,12 +9,6 @@
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
 #  confirmation_token     :string
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
@@ -24,6 +18,7 @@
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/forms/user_form_spec.rb
+++ b/spec/forms/user_form_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UserForm do
       expect(validate).to eq false
     end
 
-    it 'validates uniquness' do
+    it 'validates uniqueness' do
       create(:user, email: user_attributes[:email])
 
       expect(validate).to eq false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,12 +9,6 @@
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
 #  confirmation_token     :string
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
@@ -24,6 +18,7 @@
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -9,12 +9,6 @@
 #  encrypted_password     :string           default(""), not null
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
 #  confirmation_token     :string
 #  confirmed_at           :datetime
 #  confirmation_sent_at   :datetime
@@ -24,6 +18,7 @@
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/use_cases/users/create_user_spec.rb
+++ b/spec/use_cases/users/create_user_spec.rb
@@ -21,6 +21,43 @@ RSpec.describe Users::CreateUser do
         expect { perform }.to change(Devise::Mailer.deliveries, :count).by 1
       end
     end
+
+    describe 'unconfirmed user already exists' do
+      let!(:user) do
+        create(:user, :unconfirmed, email: user_attributes[:email])
+      end
+
+      it 'does not create a user' do
+        expect { perform }.not_to change(User, :count)
+      end
+
+      it 'updates the password' do
+        expect do
+          perform
+          user.reload
+        end.to change(user, :encrypted_password)
+      end
+
+      it 'resends the confirmation email' do
+        Sidekiq::Testing.inline! do
+          expect { perform }.to change(Devise::Mailer.deliveries, :count).by 1
+        end
+      end
+    end
+  end
+
+  describe 'confirmed user already exists' do
+    let!(:user) { create(:user, user_attributes) }
+
+    it { is_expected.not_to perform_successfully }
+
+    it 'does not create a user' do
+      expect { perform }.not_to change(User, :count)
+    end
+
+    it 'adds form errors to the use case' do
+      expect(perform.errors.messages).not_to be_empty
+    end
   end
 
   describe 'invalid attributes' do


### PR DESCRIPTION
#6 

When a user attempts signup, if an unconfirmed account with the same email exists, the confirmation is resent.

Note: To prevent spam, this email is only resent if the last attempt was more than 1 minute ago (this is still susceptible to spamming, but much more unlikely)